### PR TITLE
Add `dragStartDelay` as a controller parameter

### DIFF
--- a/lib/src/widgets/controller.dart
+++ b/lib/src/widgets/controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import '../../flutter_gantt.dart';
@@ -21,12 +22,24 @@ class GanttController extends ChangeNotifier {
   List<DateTime> _highlightedDates = [];
   bool _enableDraggable = true;
   bool _allowParentIndependentDateMovement = false;
+  Duration _dragStartDelay;
 
   GanttTheme? _theme;
 
   GanttTheme get theme => _theme ?? GanttTheme();
 
   set theme(GanttTheme? value) => _theme = value;
+
+  /// The current delay of starting drag.
+  Duration get dragStartDelay => _dragStartDelay;
+
+  /// Sets the delay of starting drag and notifies listeners if changed.
+  set dragStartDelay(Duration value) {
+    if (value != _dragStartDelay) {
+      _dragStartDelay = value;
+      notifyListeners();
+    }
+  }
 
   /// The current start date of the visible range.
   DateTime get startDate => _startDate;
@@ -177,11 +190,15 @@ class GanttController extends ChangeNotifier {
   /// Creates a [GanttController] with optional start date.
   ///
   /// If no [startDate] is provided, defaults to 30 days before today.
-  GanttController({DateTime? startDate, int? daysViews})
-    : _startDate =
-          (startDate?.toDate ??
-              DateTime.now().toDate.subtract(Duration(days: 30))),
-      _daysViews = daysViews;
+  GanttController({
+    DateTime? startDate,
+    int? daysViews,
+    Duration dragStartDelay = kLongPressTimeout,
+  }) : _startDate =
+           (startDate?.toDate ??
+               DateTime.now().toDate.subtract(Duration(days: 30))),
+       _daysViews = daysViews,
+       _dragStartDelay = dragStartDelay;
 
   /// Adds a listener for activity dates changes.
   void addOnActivityChangedListener(GanttActivityOnChangedEvent listener) {

--- a/lib/src/widgets/row.dart
+++ b/lib/src/widgets/row.dart
@@ -119,6 +119,7 @@ class _GanttActivityRowState extends State<GanttActivityRow> {
             left: 0,
             bottom: 0,
             child: LongPressDraggable<GanttActivity>(
+              delay: _ctrl.controller.dragStartDelay,
               feedback: draggableEdge,
               data: activity,
               axis: Axis.horizontal,
@@ -156,6 +157,7 @@ class _GanttActivityRowState extends State<GanttActivityRow> {
             right: 0,
             top: 0,
             child: LongPressDraggable<GanttActivity>(
+              delay: _ctrl.controller.dragStartDelay,
               feedback: draggableEdge,
               data: activity,
               axis: Axis.horizontal,
@@ -193,6 +195,7 @@ class _GanttActivityRowState extends State<GanttActivityRow> {
       );
 
       final dragCell = LongPressDraggable<GanttActivity>(
+        delay: _ctrl.controller.dragStartDelay,
         data: activity,
         axis: Axis.horizontal,
         feedback: Material(


### PR DESCRIPTION
This pull request adds a `dragStartDelay` parameter to the controller and wires it through to the widget’s LongPressDraggable, allowing the drag start delay to be configured externally.